### PR TITLE
cmake: Add -fanalyzer option to GCC compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ if(APPLE)
 	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
 endif()
 
+if(CMAKE_C_COMPILER_ID STREQUAL GNU)
+	target_compile_options(${PROJECT_NAME} PRIVATE -fanalyzer)
+endif()
+
 setup_plugin_target(${CMAKE_PROJECT_NAME})
 
 configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Add `-fanalyzer` option to GCC compiler.

The option will further analyze the code statically and warn potential errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on Fedora 41.
CI will test on the result on Ubuntu.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
